### PR TITLE
[SPVS] Add CODEOWNERS for security-sensitive file review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,35 @@
+# .github/CODEOWNERS — vscode-extension
+# Code Owners — see technical_guidelines_secure_software_pipelines.md
+# Last matching rule wins. More specific patterns go below general ones.
+
+# Default: repo maintainers
+*                                       @xygeni/scan-integration
+
+# GitHub configuration — security review
+/.github/                               @xygeni/security
+
+# CI/CD workflows — security + release engineering review
+/.github/workflows/                     @xygeni/security @xygeni/release-engineering
+
+# CODEOWNERS itself — self-protection
+/.github/CODEOWNERS                     @xygeni/security
+
+# Dependency descriptors — supply chain attack surface
+pom.xml                                 @xygeni/security @xygeni/scan-integration
+package.json                            @xygeni/security @xygeni/scan-integration
+package-lock.json                       @xygeni/security @xygeni/scan-integration
+build.gradle.kts                        @xygeni/security @xygeni/scan-integration
+.npmrc                                  @xygeni/security
+settings.xml                            @xygeni/security
+
+# Xygenibot configuration — SCA and remediation policy
+xygenibot.yml                           @xygeni/security
+
+# Container definitions
+Dockerfile*                             @xygeni/security @xygeni/release-engineering
+docker-compose*                         @xygeni/security @xygeni/release-engineering
+
+# Pre-commit hooks
+.pre-commit-hooks.yaml                  @xygeni/security
+.pre-commit-config.yaml                 @xygeni/security
+


### PR DESCRIPTION
## Summary

Add `.github/CODEOWNERS` to route changes to security-sensitive files to the appropriate review teams.

Protected file categories:
- CI/CD workflows → `xygeni/security` + `xygeni/release-engineering`
- Dependency descriptors (pom.xml, package.json, etc.) → `xygeni/security` + repo team
- Container definitions → `xygeni/security` + `xygeni/release-engineering`
- Xygenibot config, pre-commit hooks, `.github/` config → `xygeni/security`

The org rulesets now have `require_code_owner_review: true`, so this activates the moment the PR merges.

## Test plan

- [ ] After merge, open a PR modifying a `.github/workflows/` file — verify security + release-engineering are auto-requested
- [ ] Open a PR modifying regular code — verify only repo team is requested

Ref: xygeni/product-backlog#4431

🤖 Generated with [Claude Code](https://claude.com/claude-code)