### PR TITLE
[SPVS] Add explicit permissions to workflows

### DIFF
--- a/.github/workflows/build-test-publish-openvsx.yml
+++ b/.github/workflows/build-test-publish-openvsx.yml
@@ -3,6 +3,10 @@ name: Publish VS Code Extension to OpenVSX Marketplace
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write        # trstringer/manual-approval creates/closes approval issues
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -3,6 +3,10 @@ name: Publish VS Code Extension to Marketplace
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write        # trstringer/manual-approval creates/closes approval issues
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop, 'release/**' ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -8,6 +8,9 @@ on:
 env:
   RUNNING_GITHUB: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/testing-demo.yml
+++ b/.github/workflows/testing-demo.yml
@@ -8,6 +8,9 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   xygeni-scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit permissions to 5 workflows missing them
- Publish workflows get `issues: write` for `trstringer/manual-approval` gate
- Enforces least-privilege for GITHUB_TOKEN per OWASP SPVS V3.2

Ref: xygeni/product-backlog#4434

## Test plan
- [ ] Verify CI still runs on push/PR
- [ ] Verify publish workflows' manual approval gate still works
- [ ] Verify nightly build still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)